### PR TITLE
Fix getNext method generation

### DIFF
--- a/php/clienttpl.go
+++ b/php/clienttpl.go
@@ -47,6 +47,7 @@ use {{ $n }};
 
 {{ $package := .File.Package -}}
 {{ $svc := .Service.Name -}}
+{{ $once := 0 -}}
 
 class {{ .Service.Name | client }} extends \OpenSwoole\GRPC\BaseStub
 {
@@ -65,11 +66,12 @@ class {{ .Service.Name | client }} extends \OpenSwoole\GRPC\BaseStub
         ['\{{ $ns.Namespace }}\{{ name $ns $m.OutputType }}', 'decode'],
         $metadata); 
     }
-
-    public function getNext(): HelloReply
-    {
-        return $this->_getData();
-    }
+{{if eq $once 0}}
+	public function getNext(): object {
+	    return $this->_getData();
+	}
+{{end -}}
+{{ $once = 1}}
 {{- else}}
     /**
     * @param {{ name $ns $m.InputType }} $request


### PR DESCRIPTION
Fix 2 issues: 
1. generating getNext() method with wrong returned type
2. In case of more than 1 ServerStreaming RPCs in proto file - generating more than 1 the same getNext() methods in one class.